### PR TITLE
updated control 010114 to also encorporate /etc/sudoers.d files and c…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ ubtu18stig_audit_disruptive: true
 
 ubtu18stig_skip_for_travis: false
 
-ubtu18_skip_reboot: false
+ubtu18_skip_reboot: true
 
 ubtu18stig_workaround_for_disa_benchmark: true
 ubtu18stig_workaround_for_ssg_benchmark: true

--- a/tasks/fix-cat2.yml
+++ b/tasks/fix-cat2.yml
@@ -492,15 +492,36 @@
       - passwords
 
 - name: "MEDIUM | UBTU-18-010114 | PATCH | The Ubuntu operating system must require users to re-authenticate for privilege escalation and changing roles."
-  replace:
-      path: /etc/sudoers
-      regexp: "{{ item.regexp }}"
-      replace: "{{ item.replace }}"
-  with_items:
-      - { regexp: '^([^#|{% if system_is_ec2 %}ec2-user{% endif %}].*)NOPASSWD(.*)', replace: '\1PASSWD\2' }
-      - { regexp: '^([^#].*)!authenticate(.*)', replace: '\1authenticate\2' }
-  loop_control:
-      label: "{{ item.replace }}"
+  block:
+      - name: "MEDIUM | UBTU-18-010114 | AUDIT | The Ubuntu operating system must require users to re-authenticate for privilege escalation and changing roles. | Get sudoers nopasswd files"
+        shell: egrep -i '(nopasswd)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+        changed_when: false
+        failed_when: false
+        register: ubtu_18_010114_sudoers_nopasswd_status
+
+      - name: "MEDIUM | UBTU-18-010114 | AUDIT | The Ubuntu operating system must require users to re-authenticate for privilege escalation and changing roles. | Get sudoers authenticate files"
+        shell: egrep -i '(!authenticate)' /etc/sudoers /etc/sudoers.d/* | cut -d':' -f1
+        changed_when: false
+        failed_when: false
+        register: ubtu_18_010114_sudoers_authenticate_status
+
+      - name: "MEDIUM | UBTU-18-010114 | PATCH | The Ubuntu operating system must require users to re-authenticate for privilege escalation and changing roles."
+        replace:
+            path: "{{ item }}"
+            regexp: '^([^#|{% if system_is_ec2 %}ec2-user{% endif %}].*)NOPASSWD(.*)'
+            replace: '\1PASSWD\2' 
+        with_items:
+            - "{{ ubtu_18_010114_sudoers_nopasswd_status.stdout_lines }}"
+        when: ubtu_18_010114_sudoers_nopasswd_status.stdout | length >= 1
+
+      - name: "MEDIUM | UBTU-18-010114 | PATCH | The Ubuntu operating system must require users to re-authenticate for privilege escalation and changing roles."
+        replace:
+            path: "{{ item }}"
+            regexp: '^([^#].*)!authenticate(.*)'
+            replace: '\1authenticate\2'
+        with_items:
+            - "{{ ubtu_18_010114_sudoers_authenticate_status.stdout_lines }}"
+        when: ubtu_18_010114_sudoers_authenticate_status.stdout | length >= 1
   when:
       - ubtu_18_010114
   tags:


### PR DESCRIPTION
Signed-off-by: George Nalen <georgen@mindpointgroup.com>

**Overall Review of Changes:**
Updated the control 010114 in CAT2 to incorporate /etc/sudoers.d files. Also changed the default value for skip reboot to true so no auto reboots happen automatically without changing the var. 

**Issue Fixes:**
N/A

**Enhancements:**
Sudoers.d files are now included

**How has this been tested?:**
locally

